### PR TITLE
add preview mode #24

### DIFF
--- a/previewers/js/retriever.js
+++ b/previewers/js/retriever.js
@@ -2,6 +2,7 @@ var queryParams = null;
 var datasetUrl = null;
 var version = null;
 var fileDownloadUrl = null;
+var previewMode = false;
 
 function startPreview(retrieveFile) {
 	// Retrieve tool launch parameters from URL
@@ -14,6 +15,8 @@ function startPreview(retrieveFile) {
 			+ queryParams.get("datasetid") + "/versions/"
 			+ queryParams.get("datasetversion");
 	var apiKey = queryParams.get("key");
+	// Hide header and citation to embed on Dataverse file landing page.
+	previewMode = queryParams.get("preview");
 	if (apiKey != null) {
 		fileUrl = fileUrl + "&key=" + apiKey;
 		versionUrl = versionUrl + "?key=" + apiKey;
@@ -146,6 +149,11 @@ function addStandardPreviewHeader(file, title, authors) {
 	if(file.creationDate != null) {
 		header.append($("<div/>").addClass("preview-note").text(
 			"File uploaded on " + file.creationDate));
+	}
+	if (previewMode === 'true') {
+		$('#logo').hide();
+		$('.page-title').hide();
+		$('.preview-header').hide();
 	}
 }
 


### PR DESCRIPTION
For #24 (not sure if it closes it yet).

@qqmyers before you even consider merging this pull request, I have some meta questions. 😄 

(I noticed you gave me push access to this repo so I didn't bother forking.)

Do you know why `git diff` and `git commit` shows weird line endings? Should I try to get rid of them? I'll attach some screenshots below. I hacked on retriever.js on a CentOS EC2 instance and then copied it down to my Mac to actually commit and push the branch.

## git diff (I'm not used to seeing all these `^M`'s)

![Screen Shot 2019-10-22 at 5 32 31 PM](https://user-images.githubusercontent.com/21006/67335979-988ab180-f4f2-11e9-95db-a41c60967143.png)

## git commit (looks relatively normal or at least consistent, but I don't usually a `^M` on every line like this.)

![Screen Shot 2019-10-22 at 5 33 04 PM](https://user-images.githubusercontent.com/21006/67335980-988ab180-f4f2-11e9-9237-90998242e846.png)

You also mentioned something at https://github.com/QualitativeDataRepository/dataverse-previewers/issues/24#issuecomment-545033058 about possibly disabling an API call. Do you want me to look into that or should that be an optimization we get in later?

Finally, things are looking pretty good on Chrome but on Firefox I'm getting a mysterious spinner. Do you know why? Screenshots below.

## Chrome

![Screen Shot 2019-10-22 at 5 42 16 PM](https://user-images.githubusercontent.com/21006/67336502-79d8ea80-f4f3-11e9-8203-93e9fc1e8bdf.png)

## Firefox

![Screen Shot 2019-10-22 at 5 43 03 PM](https://user-images.githubusercontent.com/21006/67336504-79d8ea80-f4f3-11e9-9249-be17ffd68908.png)
