### PR TITLE
add preview mode support #24

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ You should be able to cut/paste any/all of the commands below to run on your Dat
 >  \\"description\\":\\"Read the text file.\\",
 >  \\"scope\\":\\"file\\",
 >  \\"type\\":\\"explore\\",
+>  \\"hasPreviewMode\\":\\"true\\",
 >  \\"toolUrl\\":\\"https://qualitativedatarepository.github.io/dataverse-previewers/previewers/TextPreview.html\",
 >  \\"toolParameters\\": {
 >      \\"queryParameters\\":[
@@ -56,6 +57,7 @@ You should be able to cut/paste any/all of the commands below to run on your Dat
 >  \\"description\\":\\"View the html file.\\",
 >  \\"scope\\":\\"file\\",
 >  \\"type\\":\\"explore\\",
+>  \\"hasPreviewMode\\":\\"true\\",
 >  \\"toolUrl\\":\\"https://qualitativedatarepository.github.io/dataverse-previewers/previewers/HtmlPreview.html\",
 >  \\"toolParameters\\": {
 >      \\"queryParameters\\":[
@@ -75,6 +77,7 @@ You should be able to cut/paste any/all of the commands below to run on your Dat
 >  \\"description\\":\\"Listen to an audio file.\\",
 >  \\"scope\\":\\"file\\",
 >  \\"type\\":\\"explore\\",
+>  \\"hasPreviewMode\\":\\"true\\",
 >  \\"toolUrl\\":\\"https://qualitativedatarepository.github.io/dataverse-previewers/previewers/AudioPreview.html\",
 >  \\"toolParameters\\": {
 >      \\"queryParameters\\":[
@@ -94,6 +97,7 @@ You should be able to cut/paste any/all of the commands below to run on your Dat
 >  \\"description\\":\\"Listen to an audio file.\\",
 >  \\"scope\\":\\"file\\",
 >  \\"type\\":\\"explore\\",
+>  \\"hasPreviewMode\\":\\"true\\",
 >  \\"toolUrl\\":\\"https://qualitativedatarepository.github.io/dataverse-previewers/previewers/AudioPreview.html\",
 >  \\"toolParameters\\": {
 >      \\"queryParameters\\":[
@@ -113,6 +117,7 @@ You should be able to cut/paste any/all of the commands below to run on your Dat
 >  \\"description\\":\\"Preview an image file.\\",
 >  \\"scope\\":\\"file\\",
 >  \\"type\\":\\"explore\\",
+>  \\"hasPreviewMode\\":\\"true\\",
 >  \\"toolUrl\\":\\"https://qualitativedatarepository.github.io/dataverse-previewers/previewers/ImagePreview.html\",
 >  \\"toolParameters\\": {
 >      \\"queryParameters\\":[
@@ -132,6 +137,7 @@ You should be able to cut/paste any/all of the commands below to run on your Dat
 >  \\"description\\":\\"Preview an image file.\\",
 >  \\"scope\\":\\"file\\",
 >  \\"type\\":\\"explore\\",
+>  \\"hasPreviewMode\\":\\"true\\",
 >  \\"toolUrl\\":\\"https://qualitativedatarepository.github.io/dataverse-previewers/previewers/ImagePreview.html\",
 >  \\"toolParameters\\": {
 >      \\"queryParameters\\":[
@@ -151,6 +157,7 @@ You should be able to cut/paste any/all of the commands below to run on your Dat
 >  \\"description\\":\\"Preview an image file.\\",
 >  \\"scope\\":\\"file\\",
 >  \\"type\\":\\"explore\\",
+>  \\"hasPreviewMode\\":\\"true\\",
 >  \\"toolUrl\\":\\"https://qualitativedatarepository.github.io/dataverse-previewers/previewers/ImagePreview.html\",
 >  \\"toolParameters\\": {
 >      \\"queryParameters\\":[
@@ -170,6 +177,7 @@ You should be able to cut/paste any/all of the commands below to run on your Dat
 >  \\"description\\":\\"Preview an image file.\\",
 >  \\"scope\\":\\"file\\",
 >  \\"type\\":\\"explore\\",
+>  \\"hasPreviewMode\\":\\"true\\",
 >  \\"toolUrl\\":\\"https://qualitativedatarepository.github.io/dataverse-previewers/previewers/ImagePreview.html\",
 >  \\"toolParameters\\": {
 >      \\"queryParameters\\":[
@@ -189,6 +197,7 @@ You should be able to cut/paste any/all of the commands below to run on your Dat
 >  \\"description\\":\\"Read a pdf document.\\",
 >  \\"scope\\":\\"file\\",
 >  \\"type\\":\\"explore\\",
+>  \\"hasPreviewMode\\":\\"true\\",
 >  \\"toolUrl\\":\\"https://qualitativedatarepository.github.io/dataverse-previewers/previewers/PDFPreview.html\",
 >  \\"toolParameters\\": {
 >      \\"queryParameters\\":[
@@ -208,6 +217,7 @@ You should be able to cut/paste any/all of the commands below to run on your Dat
 >  \\"description\\":\\"Watch a video file.\\",
 >  \\"scope\\":\\"file\\",
 >  \\"type\\":\\"explore\\",
+>  \\"hasPreviewMode\\":\\"true\\",
 >  \\"toolUrl\\":\\"https://qualitativedatarepository.github.io/dataverse-previewers/previewers/VideoPreview.html\",
 >  \\"toolParameters\\": {
 >      \\"queryParameters\\":[
@@ -227,6 +237,7 @@ You should be able to cut/paste any/all of the commands below to run on your Dat
 >  \\"description\\":\\"Watch a video file.\\",
 >  \\"scope\\":\\"file\\",
 >  \\"type\\":\\"explore\\",
+>  \\"hasPreviewMode\\":\\"true\\",
 >  \\"toolUrl\\":\\"https://qualitativedatarepository.github.io/dataverse-previewers/previewers/VideoPreview.html\",
 >  \\"toolParameters\\": {
 >      \\"queryParameters\\":[
@@ -246,6 +257,7 @@ You should be able to cut/paste any/all of the commands below to run on your Dat
 >  \\"description\\":\\"Watch a video file.\\",
 >  \\"scope\\":\\"file\\",
 >  \\"type\\":\\"explore\\",
+>  \\"hasPreviewMode\\":\\"true\\",
 >  \\"toolUrl\\":\\"https://qualitativedatarepository.github.io/dataverse-previewers/previewers/VideoPreview.html\",
 >  \\"toolParameters\\": {
 >      \\"queryParameters\\":[
@@ -265,6 +277,7 @@ You should be able to cut/paste any/all of the commands below to run on your Dat
 >  \\"description\\":\\"View the spreadsheet data.\\",
 >  \\"scope\\":\\"file\\",
 >  \\"type\\":\\"explore\\",
+>  \\"hasPreviewMode\\":\\"true\\",
 >  \\"toolUrl\\":\\"https://qualitativedatarepository.github.io/dataverse-previewers/previewers/SpreadsheetPreview.html\",
 >  \\"toolParameters\\": {
 >      \\"queryParameters\\":[
@@ -284,6 +297,7 @@ You should be able to cut/paste any/all of the commands below to run on your Dat
 >  \\"description\\":\\"View the spreadsheet data.\\",
 >  \\"scope\\":\\"file\\",
 >  \\"type\\":\\"explore\\",
+>  \\"hasPreviewMode\\":\\"true\\",
 >  \\"toolUrl\\":\\"https://qualitativedatarepository.github.io/dataverse-previewers/previewers/SpreadsheetPreview.html\",
 >  \\"toolParameters\\": {
 >      \\"queryParameters\\":[
@@ -303,6 +317,7 @@ You should be able to cut/paste any/all of the commands below to run on your Dat
 >  \\"description\\":\\"View the Stata file as text.\\",
 >  \\"scope\\":\\"file\\",
 >  \\"type\\":\\"explore\\",
+>  \\"hasPreviewMode\\":\\"true\\",
 >  \\"toolUrl\\":\\"https://qualitativedatarepository.github.io/dataverse-previewers/previewers/TextPreview.html\",
 >  \\"toolParameters\\": {
 >      \\"queryParameters\\":[
@@ -322,6 +337,7 @@ You should be able to cut/paste any/all of the commands below to run on your Dat
 >  \\"description\\":\\"View the R file as text.\\",
 >  \\"scope\\":\\"file\\",
 >  \\"type\\":\\"explore\\",
+>  \\"hasPreviewMode\\":\\"true\\",
 >  \\"toolUrl\\":\\"https://qualitativedatarepository.github.io/dataverse-previewers/previewers/TextPreview.html\",
 >  \\"toolParameters\\": {
 >      \\"queryParameters\\":[
@@ -341,6 +357,7 @@ You should be able to cut/paste any/all of the commands below to run on your Dat
 >  \\"description\\":\\"View the annotation entries in a file.\\",
 >  \\"scope\\":\\"file\\",
 >  \\"type\\":\\"explore\\",
+>  \\"hasPreviewMode\\":\\"true\\",
 >  \\"toolUrl\\":\\"https://qualitativedatarepository.github.io/dataverse-previewers/previewers/HypothesisPreview.html\",
 >  \\"toolParameters\\": {
 >      \\"queryParameters\\":[

--- a/previewers/js/retriever.js
+++ b/previewers/js/retriever.js
@@ -2,6 +2,7 @@ var queryParams = null;
 var datasetUrl = null;
 var version = null;
 var fileDownloadUrl = null;
+var previewMode = null;
 
 function startPreview(retrieveFile) {
 	// Retrieve tool launch parameters from URL
@@ -14,6 +15,8 @@ function startPreview(retrieveFile) {
 			+ queryParams.get("datasetid") + "/versions/"
 			+ queryParams.get("datasetversion");
 	var apiKey = queryParams.get("key");
+	// Hide header and citation to embed on Dataverse file landing page.
+	previewMode = queryParams.get("preview");
 	if (apiKey != null) {
 		fileUrl = fileUrl + "&key=" + apiKey;
 		versionUrl = versionUrl + "?key=" + apiKey;
@@ -95,22 +98,24 @@ function startPreview(retrieveFile) {
 
 var filePageUrl = null;
 function addStandardPreviewHeader(file, title, authors) {
-	// Add favicon from source Dataverse
-	$('head')
-			.append(
-					$('<link/>')
-							.attr('type', 'image/png')
-							.attr('rel', 'icon')
-							.attr(
-									'href',
-									queryParams.get("siteUrl")
-											+ '/javax.faces.resource/images/favicondataverse.png.xhtml'));
-	// Add logo from source Dataverse or use a local one
-	$('#logo')
-			.attr('src', queryParams.get("siteUrl") + '/logos/preview_logo.png')
-			.attr(
-					'onerror',
-					'this.onerror=null;this.src="/dataverse-previewers/previewers/images/logo_placeholder.png";');
+	if (previewMode !== 'true') {
+		// Add favicon from source Dataverse
+		$('head')
+				.append(
+						$('<link/>')
+								.attr('type', 'image/png')
+								.attr('rel', 'icon')
+								.attr(
+										'href',
+										queryParams.get("siteUrl")
+												+ '/javax.faces.resource/images/favicondataverse.png.xhtml'));
+		// Add logo from source Dataverse or use a local one, unless we are in preview mode
+		$('#logo')
+				.attr('src', queryParams.get("siteUrl") + '/logos/preview_logo.png')
+				.attr(
+						'onerror',
+						'this.onerror=null;this.src="/dataverse-previewers/previewers/images/logo_placeholder.png";');
+	}
 	//Footer
     $('body').append($('<div/>').html("Previewers originally developed by <a href='https://qdr.syr.edu'>QDR</a> and maintained at <a href='https://github.com/QualitativeDataRepository/dataverse-previewers'>https://github.com/QualitativeDataRepository/dataverse-previewers</a>. Feedback and contributions welcome.").attr('id','footer'));
 	
@@ -146,6 +151,11 @@ function addStandardPreviewHeader(file, title, authors) {
 	if(file.creationDate != null) {
 		header.append($("<div/>").addClass("preview-note").text(
 			"File uploaded on " + file.creationDate));
+	}
+	if (previewMode === 'true') {
+		$('#logo').hide();
+		$('.page-title').hide();
+		$('.preview-header').hide();
 	}
 }
 

--- a/previewers/js/retriever.js
+++ b/previewers/js/retriever.js
@@ -119,38 +119,40 @@ function addStandardPreviewHeader(file, title, authors) {
 	//Footer
     $('body').append($('<div/>').html("Previewers originally developed by <a href='https://qdr.syr.edu'>QDR</a> and maintained at <a href='https://github.com/QualitativeDataRepository/dataverse-previewers'>https://github.com/QualitativeDataRepository/dataverse-previewers</a>. Feedback and contributions welcome.").attr('id','footer'));
 	
-    filePageUrl = queryParams.get("siteUrl") + "/file.xhtml?";
-	if (file.persistentId.length == 0) {
-		filePageUrl = filePageUrl + "fileId=" + file.id;
-	} else {
-		filePageUrl = filePageUrl + "persistentId=" + file.persistentId;
-	}
-	filePageUrl = filePageUrl + "&version=" + version;
-	var header = $('.preview-header').append($('<div/>'));
-	header.append($("<div/>").text("Filename: ").append(
-			$('<a/>').attr('href', filePageUrl).text(file.filename)).attr('id',
-			'filename'));
-	if ((file.description != null) && (file.description.length > 0)) {
-		header.append($('<div/>').html("Description: " + file.description));
-	}
-	header.append($('<div/>').text("In ").append(
-			$('<span/>').attr('id', 'dataset').append(
-					$('<a/>').attr(
-							'href',
-							queryParams.get("siteUrl")
-									+ "/dataset.xhtml?persistentId=doi:"
-									+ datasetUrl + "&version=" + version).text(
-							title))).append(
-			$('<span/>').text(" (version " + version + ")").attr('id',
-					'version')).append(
-			$('<span/>').text(", by " + authors).attr('id', 'authors')));
-	header.append($("<div/>").addClass("btn btn-default").html(
-			"<a href='" + fileDownloadUrl + "'>Download File</a>"));
-	header.append($("<div/>").addClass("btn btn-default").html(
-			"<a href=\"javascript:window.close();\">Close Preview</a>"));
-	if(file.creationDate != null) {
-		header.append($("<div/>").addClass("preview-note").text(
-			"File uploaded on " + file.creationDate));
+	if (previewMode !== 'true') {
+		filePageUrl = queryParams.get("siteUrl") + "/file.xhtml?";
+		if (file.persistentId.length == 0) {
+			filePageUrl = filePageUrl + "fileId=" + file.id;
+		} else {
+			filePageUrl = filePageUrl + "persistentId=" + file.persistentId;
+		}
+		filePageUrl = filePageUrl + "&version=" + version;
+		var header = $('.preview-header').append($('<div/>'));
+		header.append($("<div/>").text("Filename: ").append(
+				$('<a/>').attr('href', filePageUrl).text(file.filename)).attr('id',
+				'filename'));
+		if ((file.description != null) && (file.description.length > 0)) {
+			header.append($('<div/>').html("Description: " + file.description));
+		}
+		header.append($('<div/>').text("In ").append(
+				$('<span/>').attr('id', 'dataset').append(
+						$('<a/>').attr(
+								'href',
+								queryParams.get("siteUrl")
+										+ "/dataset.xhtml?persistentId=doi:"
+										+ datasetUrl + "&version=" + version).text(
+								title))).append(
+				$('<span/>').text(" (version " + version + ")").attr('id',
+						'version')).append(
+				$('<span/>').text(", by " + authors).attr('id', 'authors')));
+		header.append($("<div/>").addClass("btn btn-default").html(
+				"<a href='" + fileDownloadUrl + "'>Download File</a>"));
+		header.append($("<div/>").addClass("btn btn-default").html(
+				"<a href=\"javascript:window.close();\">Close Preview</a>"));
+		if(file.creationDate != null) {
+			header.append($("<div/>").addClass("preview-note").text(
+				"File uploaded on " + file.creationDate));
+		}
 	}
 	if (previewMode === 'true') {
 		$('#logo').hide();


### PR DESCRIPTION
Closes #24 and https://github.com/IQSS/dataverse/issues/6210

This pull request replaces #25 and incorporates feedback given there.

The screenshot below shows how the preview mode looks on a tabular file as of https://github.com/IQSS/dataverse/commit/7118939 but this code has not been merged and the design for everything outside the box in the Preview tab is not final. To follow those changes, please see https://github.com/IQSS/dataverse/issues/3758

![2019-02-25 tab_-_Open_Source_at_Harvard_-_2019-10-24_16 43 33](https://user-images.githubusercontent.com/21006/67524032-ec75d180-f67d-11e9-8e83-38978e481d29.png)
