### PR TITLE
Adding basic info about CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A collection of data file previewers that conform to the [Dataverse](https://dat
 ## Installation
 These previewers can be run without downloading them by simply running the curl command(s) below to register then with your local dataverse instance. There is one command per mimetype you wish to preview (i.e. multiple commands to cover different types of images.) You can run any/all of the commands as you like. Note that the Hypothesis annotation previewer assumes a custom mimetype and may not be useful for most Dataverses (contact QDR for more information). Dataverse 4.11+ is required.
 
+Dataverse installations configured to redirect to S3 storage for file downloads will need to enable CORS at the storage layer as well as the application layer.
+
 ## How do they work?
 The tools here are lightweight wrappers around standard HTML5 functionality (e.g. audio, video), or third-party libraries (pdf) or some combination (e.g. standard image displays with a third-party library to allow zooming, simple text/html displays with third-party libraries used to sanitize content to avoid security issues). 
 


### PR DESCRIPTION
Closes #28 

adding a note in the installation section about CORS based on experiences enabling the previewers on Harvard Dataverse. Feel free to add/remove/edit. 