### PR TITLE
removing tiff from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,26 +173,6 @@ You should be able to cut/paste any/all of the commands below to run on your Dat
 
 >curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
 >"{
->  \\"displayName\\":\\"View Image\\",
->  \\"description\\":\\"Preview an image file.\\",
->  \\"scope\\":\\"file\\",
->  \\"type\\":\\"explore\\",
->  \\"hasPreviewMode\\":\\"true\\",
->  \\"toolUrl\\":\\"https://qualitativedatarepository.github.io/dataverse-previewers/previewers/ImagePreview.html\",
->  \\"toolParameters\\": {
->      \\"queryParameters\\":[
->        {\\"fileid\\":\\"{fileId}\\"},
->        {\\"siteUrl\\":\\"{siteUrl}\\"},
->        {\\"key\\":\\"{apiToken}\\"},
->        {\\"datasetid\\":\\"{datasetId}\\"},
->        {\\"datasetversion\\":\\"{datasetVersion}\\"}
->      ]
->    },
->  \\"contentType\\":\\"image/tiff\\"
->}"
-
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->"{
 >  \\"displayName\\":\\"Read Document\\",
 >  \\"description\\":\\"Read a pdf document.\\",
 >  \\"scope\\":\\"file\\",


### PR DESCRIPTION
Closes #29, which has some more details. 

Short version: Tiff files aren't previewable across several common browsers. This proposal is to remove this bit from the readme. 